### PR TITLE
fix: add missing resume_token when stopping early

### DIFF
--- a/src/aws-mcp-server/awslabs/aws_mcp_server/core/aws/pagination.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/core/aws/pagination.py
@@ -165,6 +165,9 @@ def build_result(
 
         elapsed_time = time.time() - start_time
         if _should_stop_early(elapsed_time, remaining_tokens, is_first_page):
+            if is_first_page:
+                # Setting resume_token manually because this is not populated if we only process the first page.
+                page_iterator.resume_token = page_iterator._get_next_token(page)
             break
 
     _finalize_result(result, page_iterator, pages_processed)

--- a/src/aws-mcp-server/tests/test_pagination.py
+++ b/src/aws-mcp-server/tests/test_pagination.py
@@ -109,7 +109,7 @@ def test_build_result_max_tokens_first_page():
 
     mock_page_iter.__iter__.return_value = get_pages()
     mock_page_iter.result_keys = [jmespath.compile('Functions')]
-    mock_page_iter.resume_token = 'PaginationToken'
+    mock_page_iter.resume_token = None
     mock_paginator._pagination_cfg = {'output_token': 'NextToken'}
     mock_paginator.paginate.return_value = mock_page_iter
 


### PR DESCRIPTION
### Notes
Noticed during bug bash that the `resume_token` field on the botocore PageIterator is only populated after processing the first page so setting it manually if we stop early after the first page during pagination.

### Testing
`pytest` + manual testing

mcp/src/aws-mcp-server
```sh
❯ pre-commit run --all-files
Install project dependencies.............................................Passed
ensure confirm-list up-to-date...........................................Passed
```

/mcp
```sh
❯ pre-commit run --all-files
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check that executables have shebangs.....................................Passed
check illegal windows names..........................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
check that scripts with shebangs are executable..........................Passed
check for broken symlinks............................(no files to check)Skipped
check toml...............................................................Passed
check xml............................................(no files to check)Skipped
check non-mkdocs yaml....................................................Passed
check mkdocs yaml........................................................Passed
fix end of files.........................................................Passed
debug statements (python)................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
forbid submodules....................................(no files to check)Skipped
pretty format json.......................................................Passed
trim trailing whitespace.................................................Passed
ruff.....................................................................Passed
ruff-format..............................................................Passed
Detect secrets...........................................................Passed
check license header.....................................................Passed
```
