### PR TITLE
feat: Throw error when JMESPATH expression for --query cannot be parsed

### DIFF
--- a/src/aws-mcp-server/awslabs/aws_mcp_server/core/common/command.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/core/common/command.py
@@ -15,6 +15,7 @@
 import dataclasses
 from .command_metadata import CommandMetadata
 from botocore import xform_name
+from jmespath.parser import ParsedResult
 from typing import Any
 
 
@@ -25,7 +26,7 @@ class IRCommand:
     command_metadata: CommandMetadata
     parameters: dict[str, Any]
     region: str | None = None
-    client_side_query: str | None = None
+    client_side_filter: ParsedResult | None = None
     is_awscli_customization: bool = False
 
     @property

--- a/src/aws-mcp-server/awslabs/aws_mcp_server/core/common/errors.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/core/common/errors.py
@@ -539,3 +539,30 @@ class RequestSerializationError(CommandValidationError):
             reason=str(self),
             context={'service': self._service, 'operation': self._operation, 'msg': self._msg},
         )
+
+
+class ClientSideFilterError(CommandValidationError):
+    """Thrown when JMESPATH expression of the client-side filter could not be parsed."""
+
+    _message = "Error parsing client-side filter '{client_side_query}': {msg}"
+
+    def __init__(self, service: str, operation: str, client_side_query: str, msg: str):
+        """Initialize ClientSideFilterError with details."""
+        message = self._message.format(client_side_query=client_side_query, msg=msg)
+        self._service = service
+        self._operation = operation
+        self._client_side_query = client_side_query
+        self._msg = msg
+        super().__init__(message)
+
+    def as_failure(self) -> Failure:
+        """Return a Failure object representing this error."""
+        return Failure(
+            reason=str(self),
+            context={
+                'service': self._service,
+                'operation': self._operation,
+                'client_side_query': self._client_side_query,
+                'msg': self._msg,
+            },
+        )

--- a/src/aws-mcp-server/tests/aws/test_driver.py
+++ b/src/aws-mcp-server/tests/aws/test_driver.py
@@ -41,7 +41,6 @@ from tests.fixtures import S3_CLI_NO_REGION
                 command=IRCommand(
                     command_metadata=CommandMetadata('s3', None, 'ls'),
                     parameters={},
-                    client_side_query=None,
                     is_awscli_customization=True,
                 ),
                 command_metadata=CommandMetadata('s3', None, 'ls'),
@@ -53,7 +52,6 @@ from tests.fixtures import S3_CLI_NO_REGION
                 command=IRCommand(
                     command_metadata=CommandMetadata('s3', None, 'ls'),
                     parameters={},
-                    client_side_query=None,
                     is_awscli_customization=True,
                 ),
                 command_metadata=CommandMetadata('s3', None, 'ls'),
@@ -65,7 +63,6 @@ from tests.fixtures import S3_CLI_NO_REGION
                 command=IRCommand(
                     command_metadata=CommandMetadata('dynamodb', None, 'wait table-exists'),
                     parameters={'--table-name': 'MyTable'},
-                    client_side_query=None,
                     is_awscli_customization=True,
                 ),
                 command_metadata=CommandMetadata('dynamodb', None, 'wait table-exists'),

--- a/src/aws-mcp-server/tests/parser/test_parser.py
+++ b/src/aws-mcp-server/tests/parser/test_parser.py
@@ -2,6 +2,7 @@ import pytest
 import re
 from awslabs.aws_mcp_server.core.common.command_metadata import CommandMetadata
 from awslabs.aws_mcp_server.core.common.errors import (
+    ClientSideFilterError,
     CommandValidationError,
     ExpectedArgumentError,
     InvalidChoiceForParameterError,
@@ -584,5 +585,14 @@ def test_ssm_cli_raises_parameter_schema_validation_error_when_platform_version_
                 )
             )
         ),
+    ):
+        parse(command)
+
+
+def test_client_side_filter_error():
+    """Test that a malformed client-side filter raises an error."""
+    command = 'aws ec2 describe-instances --query "Reservations[[]"'
+    with pytest.raises(
+        ClientSideFilterError, match="Error parsing client-side filter 'Reservations[[]'*"
     ):
         parse(command)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

Throw error when JMESPATH expression for --query cannot be parsed, instead of silently ignoring the expression and returning the complete result.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
