### PR TITLE
fix: aws-mcp readme updates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,6 @@ Model Context Protocol (MCP) server for interacting with AWS services and resour
 - Create, update, and manage AWS resources across all services
 - Help in AWS CLI command selection
 - Access to latest AWS API features and services beyond LLM knowledge cutoff dates
-- Safe resource management with proper consent mechanisms
 
 [Learn more about the aws MCP Server](servers/aws-mcp-server.md)
 

--- a/src/aws-mcp-server/README.md
+++ b/src/aws-mcp-server/README.md
@@ -4,7 +4,7 @@
 ## Overview
 The AWS MCP Server enables AI assistants to interact with AWS services and resources through AWS CLI commands. It provides programmatic access to manage your AWS infrastructure while maintaining proper security controls.
 
-This server bridges the gap between AI assistants and AWS services, allowing you to create, update, and manage AWS resources across all available services. It helps with AWS CLI command selection and provides access to the latest AWS API features and services, even those released after an AI model's knowledge cutoff date. The server implements safety measures to ensure that critical operations require explicit user approval before execution.
+This server bridges the gap between AI assistants and AWS services, allowing you to create, update, and manage AWS resources across all available services. It helps with AWS CLI command selection and provides access to the latest AWS API features and services, even those released after an AI model's knowledge cutoff date.
 
 
 ## Features
@@ -67,10 +67,10 @@ Once configured, you can ask your AI assistant questions such as:
 
 ## Security Considerations
 We primarily use credentials to control which commands this MCP server can execute. We recommend using IAM roles, in particular:
-- Using credentials for an IAM role with `AdministratorAccess` policy (usually the `Admin` IAM role) permits mutating actions (i.e. creating, deleting, modifying your AWS resources). **Note**: if you assume this role, the server will not ask for your consent or confirmation before executing mutating actions, depending on which MCP client you use, you might still get a prompt from the client.
-- Using credentials for an IAM role with `ReadOnlyAccess` policy (usually the `ReadOnly` IAM role) only allows non-mutating actions, this is sufficient if you only want to inspect.
+- Using credentials for an IAM role with `AdministratorAccess` policy (usually the `Admin` IAM role) permits mutating actions (i.e. creating, deleting, modifying your AWS resources).
+- Using credentials for an IAM role with `ReadOnlyAccess` policy (usually the `ReadOnly` IAM role) only allows non-mutating actions, this is sufficient if you only want to inspect your account.
 - Apart from IAM roles, [these alternatives](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html#cli-configure-files-examples) can also be used to configure credentials.
-- To add another layer of security, users can explicitly set the environment variable `READ_OPERATIONS_ONLY` to true in their MCP config file. When set to true, we'll compare each CLI command against a list of known read-only actions, and will only execute the command if it's found in the allowed list. IAM credentials take precedence over this environment variable.
+- To add another layer of security, users can explicitly set the environment variable `READ_OPERATIONS_ONLY` to true in their MCP config file. When set to true, we'll compare each CLI command against a list of known read-only actions, and will only execute the command if it's found in the allowed list. While this environment variable provides an additional layer of protection, IAM permissions remain the primary and most reliable security control. Users should always configure appropriate IAM roles and policies for their use case, as IAM credentials take precedence over this environment variable.
 
 
 
@@ -83,7 +83,7 @@ We primarily use credentials to control which commands this MCP server can execu
 - `AWS_PROFILE` (string, default: "default"): AWS Profile for credentials to use for command executions, 'default' will be used if not specified
 - `MAX_OUTPUT_TOKENS` (int): Limits the output of the AWS CLI command to the set amount of tokens, default sets this to unlimited. The size of data that LLMs can reason about is limited and this can become a problem when you have a large number of AWS resources in your account and you are asking questions about these resources. The tool makes a best effort estimation since tokenization is different for every LLM and will stop paginating the AWS CLI command once it estimates that the specified token limit has been reached.
 - `READ_OPERATIONS_ONLY` (boolean, default: false): Primarily IAM permissions are used to control if mutating actions are allowed, so defaulting to "false" to reduce friction. We keep this as a best effort attempt to recognize and further control read-only actions. When set to "true", restricts execution to read-only operations. For a complete list of allowed operations under this flag, refer to the [ReadOnlyAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ReadOnlyAccess.html) policy.
-- `AWS_MCP_TELEMETRY` (boolean, default: false): Allow the storage of telemetry data related to the commands executed.
+- `AWS_MCP_TELEMETRY` (boolean, default: false): Allow sending additional telemetry data to AWS related to the server configuration.
 
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Removed obsolete documentation, rephrased some vague phrasing.
