### PR TITLE
fix: Updating README

### DIFF
--- a/src/aws-mcp-server/README.md
+++ b/src/aws-mcp-server/README.md
@@ -30,9 +30,11 @@ This server bridges the gap between AI assistants and AWS services, allowing you
 
 
 ## Installation
-You can download the AWS MCP Server from GitHub. To get started using your favorite code assistant with MCP support, like Q CLI, Cursor or Cline.
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=awslabs.aws-mcp-server&config=JTdCJTIyY29tbWFuZCUyMiUzQSUyMnV2eCUyMGF3c2xhYnMuYXdzLW1jcC1zZXJ2ZXIlNDBsYXRlc3QlMjIlMkMlMjJlbnYlMjIlM0ElN0IlMjJBV1NfUkVHSU9OJTIyJTNBJTIydXMtZWFzdC0xJTIyJTdEJTdE)
 
-Add the following code to your MCP client configuration (e.g., for Amazon Q Developer CLI, edit `~/.aws/amazonq/mcp.json`). The AWS MCP server uses the default AWS profile by default. Specify a value for `AWS_PROFILE` if you want to use a different profile. Similarly, adjust the AWS Region and log level values as needed.
+Add the following code to your MCP client configuration (e.g., for Amazon Q Developer CLI, edit `~/.aws/amazonq/mcp.json`). 
+
+Remember to remove all comments when you finish configuration, otherwise the config file will not load properly.
 
 ```
 {
@@ -40,11 +42,11 @@ Add the following code to your MCP client configuration (e.g., for Amazon Q Deve
     "awslabs.aws-mcp-server": {
       "command": "uvx",
       "args": [
-        "awslabs.aws-mcp-server@latest",
+        "awslabs.aws-mcp-server@latest"
       ],
       "env": {
         "AWS_REGION": "us-east-1", // Required. Set your default region to be assumed for CLI commands, if not specified explicitly in the request.
-        "AWS_PROFILE": "profile", // Optional. AWS Profile for credentials, 'default' will be used if not specified.
+        "AWS_PROFILE": "default", // Optional. AWS Profile for credentials, 'default' will be used if not specified.
         "READ_OPERATIONS_ONLY": "false", // Optional. Only allows read-only operations as per ReadOnlyAccess policy. Default is "false"
         "AWS_MCP_TELEMETRY": "false" // Optional. Allow the storage of telemetry data. Default is "false"
       },
@@ -54,8 +56,6 @@ Add the following code to your MCP client configuration (e.g., for Amazon Q Deve
   }
 }
 ```
-
-Remember to remove all comments when you finish configuration, otherwise the config file will not load properly.
 
 Once configured, you can ask your AI assistant questions such as:
 
@@ -101,7 +101,7 @@ To make changes to this MCP locally and run it:
    ```
 
 3. Configure AWS credentials and environment variables:
-   - Ensure you have AWS credentials configured in `~/.aws/credentials` or set the appropriate environment variables.
+   - Ensure you have AWS credentials configured in `~/.aws/credentials` or set the appropriate [environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#environment-variables) in the MCP server configuration.
    - `export AWS_REGION=us-east-1` or any other region of your preference
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Minor updates in README

### Changes
> Please provide a summary of what's being changed

- Added button for 1-click installation in Cursor
- Removed trailing comma in mcp json
- Changed AWS_PROFILE value to `default` for consistency since all other env var values were also set to default values. 
- Removed redundant line about default profile since it's already mentioned in the comments of the server config json.
- Moved "Remember to remove comments" before the server
<img width="1411" alt="Screenshot 2025-07-02 at 15 17 56" src="https://github.com/user-attachments/assets/956ce28c-0b63-47a6-a5f6-2a6729edb3f8" />
 config json since users could miss it if placed after the config.
- Added link to AWS boto3 docs for environment variables to be added


### User experience

> Please share what the user experience looks like before and after this change
Attached

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
