### PR TITLE
feat: rebuild embeddings if core kb files changed

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -157,13 +157,13 @@ jobs:
 
       - name: Debug outputs
         run: |
-          echo "changed-files: ${{ needs.detect-packages.outputs.changed-files }}"
+          echo "changed-files: ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/kb/') }}"
           echo "changed-files (raw): '${{ toJson(needs.detect-packages.outputs.changed-files) }}'"
 
       - name: Debug changed files and directories
         run: |
           echo "changed-directories: ${{ needs.detect-packages.outputs.changed-directories }}"
-          echo "changed-files: ${{ fromJson(needs.detect-packages.outputs.changed-files) }}"
+          echo "joined: ${{ join(' ', fromJson(needs.detect-packages.outputs.changed-files)) }}"
           echo "matrix.package: ${{ matrix.package }}"
           echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/') }}"
           echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/') }}"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Debug changed files and directories
         run: |
           echo "changed-directories: ${{ needs.detect-packages.outputs.changed-directories }}"
-          echo "changed-files: ${{ needs.detect-packages.outputs.changed-files }}"
+          echo "changed-files: ${{ fromJson(needs.detect-packages.outputs.changed-files) }}"
           echo "matrix.package: ${{ matrix.package }}"
           echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/') }}"
           echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/') }}"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       packages: ${{ steps.find-packages.outputs.packages }}
       changed-directories: ${{ steps.find-changed-directories.outputs.changed-directories }}
+      changed-files: ${{ steps.find-changed-directories.outputs.changed-files }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -49,6 +50,7 @@ jobs:
           CHANGEDDIRECTORIES="$(echo $CHANGEDFILES | jq -r '.[] | select(. | startswith("src\/"))' | cut -d'/' -f2 | sort -u | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')"
           echo "$CHANGEDDIRECTORIES"
           echo "changed-directories=$CHANGEDDIRECTORIES" >> $GITHUB_OUTPUT
+          echo "changed-files=$CHANGEDFILES" >> $GITHUB_OUTPUT
 
       - name: Find Python packages
         id: find-packages
@@ -157,45 +159,10 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: uv run --frozen ruff check .
 
-      - name: Should rebuild AWS MCP embeddings
-        id: aws-mcp-changed
-        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server'
-        run: |
-          echo "=== DEBUGGING CHANGE DETECTION ==="
-          echo "Event: ${{ github.event_name }}"
-          echo "Current SHA: $(git rev-parse HEAD)"
-
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            COMPARE_BASE="origin/${{ github.base_ref }}"
-            echo "Base branch: ${{ github.base_ref }}"
-          else
-            # Handle new branches by comparing with main
-            if [ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]; then
-              COMPARE_BASE="main"
-              echo "New branch detected, comparing with main"
-            else
-              COMPARE_BASE="${{ github.event.before }}"
-              echo "Before SHA: ${{ github.event.before }}"
-            fi
-          fi
-
-          echo "=== CHANGED FILES ==="
-          git diff --name-only $COMPARE_BASE...HEAD
-          echo "=== FILES MATCHING PATTERN ==="
-          git diff --name-only $COMPARE_BASE...HEAD | grep "aws_mcp_server/core/kb\|aws_mcp_server/scripts\|aws_mcp_server/core/data/embeddings" || echo "No matches found"
-
-          if git diff --name-only $COMPARE_BASE...HEAD | grep -q "aws_mcp_server/core/kb\|aws_mcp_server/scripts\|aws_mcp_server/core/data/embeddings"; then
-            echo "aws-mcp-changed=true" >> $GITHUB_OUTPUT
-            echo "Changes detected - setting aws-mcp-changed=true"
-          else
-            echo "aws-mcp-changed=false" >> $GITHUB_OUTPUT
-            echo "No changes - setting aws-mcp-changed=false"
-          fi
-
       - name: Check for existing embeddings or generate new ones if it is aws-mcp-server
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server'
+        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server' && (contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/kb/') || contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/data/embeddings/') || contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/scripts/'))
         working-directory: src/${{ matrix.package }}
         run: |
           if uv run --frozen download-latest-embeddings; then

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -165,9 +165,9 @@ jobs:
           echo "changed-directories: ${{ needs.detect-packages.outputs.changed-directories }}"
           echo "changed-files: ${{ needs.detect-packages.outputs.changed-files }}"
           echo "matrix.package: ${{ matrix.package }}"
-          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/kb/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/kb/') }}"
-          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/data/embeddings/') }}"
-          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/scripts/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/scripts/') }}"
+          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/') }}"
+          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/') }}"
+          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/') }}"
 
       - name: Check for existing embeddings or generate new ones if it is aws-mcp-server
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -165,9 +165,9 @@ jobs:
           echo "changed-directories: ${{ needs.detect-packages.outputs.changed-directories }}"
           echo "changed-files: ${{ needs.detect-packages.outputs.changed-files }}"
           echo "matrix.package: ${{ matrix.package }}"
-          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/') }}"
-          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/') }}"
-          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/') }}"
+          echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/') }}"
+          echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/') }}"
+          echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/') }}"
 
       - name: Check for existing embeddings or generate new ones if it is aws-mcp-server
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,9 +32,14 @@ jobs:
           # Pull Request against target branch sha
           # Otherwise    against latest release
           if [ "$EVENT_NAME" == "push" ]; then
-            SINCE="$EVENT_BEFORE";
+            # Handle null SHA case for new branches
+            if [ "$EVENT_BEFORE" == "0000000000000000000000000000000000000000" ]; then
+              SINCE="origin/main"
+            else
+              SINCE="$EVENT_BEFORE"
+            fi
           elif [ "$EVENT_NAME" == "pull_request" ]; then
-            SINCE="$BASE_REF";
+            SINCE="$BASE_REF"
           else
             SINCE="$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName | jq -r '.[].tagName')"
           fi;
@@ -68,6 +73,11 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Fetch base branches
+        run: |
+          git fetch origin main:main
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # v6.3.0
@@ -146,6 +156,41 @@ jobs:
       - name: Run ruff check
         working-directory: src/${{ matrix.package }}
         run: uv run --frozen ruff check .
+
+      - name: Should rebuild AWS MCP embeddings
+        id: aws-mcp-changed
+        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server'
+        run: |
+          echo "=== DEBUGGING CHANGE DETECTION ==="
+          echo "Event: ${{ github.event_name }}"
+          echo "Current SHA: $(git rev-parse HEAD)"
+
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            COMPARE_BASE="origin/${{ github.base_ref }}"
+            echo "Base branch: ${{ github.base_ref }}"
+          else
+            # Handle new branches by comparing with main
+            if [ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]; then
+              COMPARE_BASE="origin/main"
+              echo "New branch detected, comparing with main"
+            else
+              COMPARE_BASE="${{ github.event.before }}"
+              echo "Before SHA: ${{ github.event.before }}"
+            fi
+          fi
+
+          echo "=== CHANGED FILES ==="
+          git diff --name-only $COMPARE_BASE...HEAD
+          echo "=== FILES MATCHING PATTERN ==="
+          git diff --name-only $COMPARE_BASE...HEAD | grep "aws_mcp_server/core/kb\|aws_mcp_server/scripts\|aws_mcp_server/core/data/embeddings" || echo "No matches found"
+
+          if git diff --name-only $COMPARE_BASE...HEAD | grep -q "aws_mcp_server/core/kb\|aws_mcp_server/scripts\|aws_mcp_server/core/data/embeddings"; then
+            echo "aws-mcp-changed=true" >> $GITHUB_OUTPUT
+            echo "Changes detected - setting aws-mcp-changed=true"
+          else
+            echo "aws-mcp-changed=false" >> $GITHUB_OUTPUT
+            echo "No changes - setting aws-mcp-changed=false"
+          fi
 
       - name: Check for existing embeddings or generate new ones if it is aws-mcp-server
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -171,7 +171,7 @@ jobs:
           else
             # Handle new branches by comparing with main
             if [ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]; then
-              COMPARE_BASE="origin/main"
+              COMPARE_BASE="main"
               echo "New branch detected, comparing with main"
             else
               COMPARE_BASE="${{ github.event.before }}"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,8 +48,8 @@ jobs:
           echo "$SINCE"
           CHANGEDFILES="$(git diff --name-only "$SINCE" HEAD | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')"
           CHANGEDDIRECTORIES="$(echo $CHANGEDFILES | jq -r '.[] | select(. | startswith("src\/"))' | cut -d'/' -f2 | sort -u | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')"
-          echo "changed-files=$CHANGEDFILES"
-          echo "changed-directories=$CHANGEDDIRECTORIES"
+          echo "$CHANGEDDIRECTORIES"
+          echo "$CHANGEDFILES"
           echo "changed-files=$CHANGEDFILES" >> $GITHUB_OUTPUT
           echo "changed-directories=$CHANGEDDIRECTORIES" >> $GITHUB_OUTPUT
 
@@ -105,74 +105,68 @@ jobs:
             sudo dpkg -L graphviz | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/graphviz/
           fi
 
-      # - name: Install Bandit
-      #   run: |
-      #     pip install --require-hashes --requirement .github/workflows/bandit-requirements.txt
-
-      # - name: Security check - Bandit
-      #   id: bandit-check
-      #   working-directory: src/${{ matrix.package }}
-      #   run: bandit -r --severity-level medium --confidence-level medium -f html -o bandit-report-${{ matrix.package }}.html -c "pyproject.toml" . || echo "status=failure" >> $GITHUB_OUTPUT
-
-      # - name: Store Bandit as Artifact
-      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-      #   with:
-      #     name: bandit-report-${{ matrix.package }}.html
-      #     path: src/${{ matrix.package }}/bandit-report-${{ matrix.package }}.html
-
-      # - name: Stop on Bandit failure
-      #   if: steps.bandit-check.outputs.status == 'failure'
-      #   run: exit 1
-
-      # - name: Install dependencies
-      #   working-directory: src/${{ matrix.package }}
-      #   run: uv sync --frozen --all-extras --dev
-
-      # - name: Run tests
-      #   working-directory: src/${{ matrix.package }}
-      #   run: |
-      #     if [ -d "tests" ]; then
-      #       uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml:${{ matrix.package }}-coverage.xml
-      #     else
-      #       echo "No tests directory found, skipping tests"
-      #     fi
-
-      # - name: Upload coverage reports to Codecov
-      #   uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 #v5.4.3
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     files: ${{ matrix.package }}-coverage.xml
-
-      # - name: Run pyright
-      #   working-directory: src/${{ matrix.package }}
-      #   run: uv run --frozen pyright
-
-      # - name: Run ruff format
-      #   working-directory: src/${{ matrix.package }}
-      #   run: uv run --frozen ruff format .
-
-      # - name: Run ruff check
-      #   working-directory: src/${{ matrix.package }}
-      #   run: uv run --frozen ruff check .
-
-      - name: Debug outputs
+      - name: Install Bandit
         run: |
-          echo "changed-files: ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/kb/') }}"
-          echo "changed-files (raw): '${{ toJson(needs.detect-packages.outputs.changed-files) }}'"
+          pip install --require-hashes --requirement .github/workflows/bandit-requirements.txt
+
+      - name: Security check - Bandit
+        id: bandit-check
+        working-directory: src/${{ matrix.package }}
+        run: bandit -r --severity-level medium --confidence-level medium -f html -o bandit-report-${{ matrix.package }}.html -c "pyproject.toml" . || echo "status=failure" >> $GITHUB_OUTPUT
+
+      - name: Store Bandit as Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bandit-report-${{ matrix.package }}.html
+          path: src/${{ matrix.package }}/bandit-report-${{ matrix.package }}.html
+
+      - name: Stop on Bandit failure
+        if: steps.bandit-check.outputs.status == 'failure'
+        run: exit 1
+
+      - name: Install dependencies
+        working-directory: src/${{ matrix.package }}
+        run: uv sync --frozen --all-extras --dev
+
+      - name: Run tests
+        working-directory: src/${{ matrix.package }}
+        run: |
+          if [ -d "tests" ]; then
+            uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml:${{ matrix.package }}-coverage.xml
+          else
+            echo "No tests directory found, skipping tests"
+          fi
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 #v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.package }}-coverage.xml
+
+      - name: Run pyright
+        working-directory: src/${{ matrix.package }}
+        run: uv run --frozen pyright
+
+      - name: Run ruff format
+        working-directory: src/${{ matrix.package }}
+        run: uv run --frozen ruff format .
+
+      - name: Run ruff check
+        working-directory: src/${{ matrix.package }}
+        run: uv run --frozen ruff check .
 
       - name: Debug changed files and directories
         run: |
           echo "changed-directories: ${{ needs.detect-packages.outputs.changed-directories }}"
-          echo "joined: ${{ join(' ', fromJson(needs.detect-packages.outputs.changed-files)) }}"
           echo "matrix.package: ${{ matrix.package }}"
-          echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/') }}"
-          echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/core/data/embeddings/') }}"
-          echo "contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/'): ${{ contains(join(' ', fromJson(needs.detect-packages.outputs.changed-files)), 'src/aws-mcp-server/awslabs/aws_mcp_server/scripts/') }}"
+          echo "contains(join(' ', core/kb/'): ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/kb/') }}"
+          echo "contains(join(' ', core/data/embeddings/'): ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/data/embeddings/') }}"
+          echo "contains(join(' ', scripts/'): ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/scripts/') }}"
 
-      - name: Check for existing embeddings or generate new ones if it is aws-mcp-server
+      - name: Check for existing embeddings or generate new ones for aws-mcp-server
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server' && (contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/kb/') || contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/data/embeddings/') || contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/scripts/'))
+        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server' && (contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/kb/') || contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/data/embeddings/') || contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/scripts/'))
         working-directory: src/${{ matrix.package }}
         run: |
           if uv run --frozen download-latest-embeddings; then

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,9 +48,10 @@ jobs:
           echo "$SINCE"
           CHANGEDFILES="$(git diff --name-only "$SINCE" HEAD | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')"
           CHANGEDDIRECTORIES="$(echo $CHANGEDFILES | jq -r '.[] | select(. | startswith("src\/"))' | cut -d'/' -f2 | sort -u | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')"
-          echo "$CHANGEDDIRECTORIES"
-          echo "changed-directories=$CHANGEDDIRECTORIES" >> $GITHUB_OUTPUT
+          echo "changed-files=$CHANGEDFILES"
+          echo "changed-directories=$CHANGEDDIRECTORIES"
           echo "changed-files=$CHANGEDFILES" >> $GITHUB_OUTPUT
+          echo "changed-directories=$CHANGEDDIRECTORIES" >> $GITHUB_OUTPUT
 
       - name: Find Python packages
         id: find-packages
@@ -75,11 +76,6 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Fetch base branches
-        run: |
-          git fetch origin main:main
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # v6.3.0
@@ -109,55 +105,69 @@ jobs:
             sudo dpkg -L graphviz | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/graphviz/
           fi
 
-      - name: Install Bandit
+      # - name: Install Bandit
+      #   run: |
+      #     pip install --require-hashes --requirement .github/workflows/bandit-requirements.txt
+
+      # - name: Security check - Bandit
+      #   id: bandit-check
+      #   working-directory: src/${{ matrix.package }}
+      #   run: bandit -r --severity-level medium --confidence-level medium -f html -o bandit-report-${{ matrix.package }}.html -c "pyproject.toml" . || echo "status=failure" >> $GITHUB_OUTPUT
+
+      # - name: Store Bandit as Artifact
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      #   with:
+      #     name: bandit-report-${{ matrix.package }}.html
+      #     path: src/${{ matrix.package }}/bandit-report-${{ matrix.package }}.html
+
+      # - name: Stop on Bandit failure
+      #   if: steps.bandit-check.outputs.status == 'failure'
+      #   run: exit 1
+
+      # - name: Install dependencies
+      #   working-directory: src/${{ matrix.package }}
+      #   run: uv sync --frozen --all-extras --dev
+
+      # - name: Run tests
+      #   working-directory: src/${{ matrix.package }}
+      #   run: |
+      #     if [ -d "tests" ]; then
+      #       uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml:${{ matrix.package }}-coverage.xml
+      #     else
+      #       echo "No tests directory found, skipping tests"
+      #     fi
+
+      # - name: Upload coverage reports to Codecov
+      #   uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 #v5.4.3
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: ${{ matrix.package }}-coverage.xml
+
+      # - name: Run pyright
+      #   working-directory: src/${{ matrix.package }}
+      #   run: uv run --frozen pyright
+
+      # - name: Run ruff format
+      #   working-directory: src/${{ matrix.package }}
+      #   run: uv run --frozen ruff format .
+
+      # - name: Run ruff check
+      #   working-directory: src/${{ matrix.package }}
+      #   run: uv run --frozen ruff check .
+
+      - name: Debug outputs
         run: |
-          pip install --require-hashes --requirement .github/workflows/bandit-requirements.txt
+          echo "changed-files: ${{ needs.detect-packages.outputs.changed-files }}"
+          echo "changed-files (raw): '${{ toJson(needs.detect-packages.outputs.changed-files) }}'"
 
-      - name: Security check - Bandit
-        id: bandit-check
-        working-directory: src/${{ matrix.package }}
-        run: bandit -r --severity-level medium --confidence-level medium -f html -o bandit-report-${{ matrix.package }}.html -c "pyproject.toml" . || echo "status=failure" >> $GITHUB_OUTPUT
-
-      - name: Store Bandit as Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: bandit-report-${{ matrix.package }}.html
-          path: src/${{ matrix.package }}/bandit-report-${{ matrix.package }}.html
-
-      - name: Stop on Bandit failure
-        if: steps.bandit-check.outputs.status == 'failure'
-        run: exit 1
-
-      - name: Install dependencies
-        working-directory: src/${{ matrix.package }}
-        run: uv sync --frozen --all-extras --dev
-
-      - name: Run tests
-        working-directory: src/${{ matrix.package }}
+      - name: Debug changed files and directories
         run: |
-          if [ -d "tests" ]; then
-            uv run --frozen pytest --cov --cov-branch --cov-report=term-missing --cov-report=xml:${{ matrix.package }}-coverage.xml
-          else
-            echo "No tests directory found, skipping tests"
-          fi
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 #v5.4.3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ matrix.package }}-coverage.xml
-
-      - name: Run pyright
-        working-directory: src/${{ matrix.package }}
-        run: uv run --frozen pyright
-
-      - name: Run ruff format
-        working-directory: src/${{ matrix.package }}
-        run: uv run --frozen ruff format .
-
-      - name: Run ruff check
-        working-directory: src/${{ matrix.package }}
-        run: uv run --frozen ruff check .
+          echo "changed-directories: ${{ needs.detect-packages.outputs.changed-directories }}"
+          echo "changed-files: ${{ needs.detect-packages.outputs.changed-files }}"
+          echo "matrix.package: ${{ matrix.package }}"
+          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/kb/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/kb/') }}"
+          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/data/embeddings/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/core/data/embeddings/') }}"
+          echo "contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/scripts/'): ${{ contains(join(' ', needs.detect-packages.outputs.changed-files), 'aws_mcp_server/scripts/') }}"
 
       - name: Check for existing embeddings or generate new ones if it is aws-mcp-server
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -128,6 +128,26 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: uv sync --frozen --all-extras --dev
 
+      - name: Check for existing embeddings or generate new ones for aws-mcp-server
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server'
+        working-directory: src/${{ matrix.package }}
+        run: |
+          CHANGED_FILES='${{ needs.detect-packages.outputs.changed-files }}'
+          if echo "$CHANGED_FILES" | grep -q 'aws_mcp_server/core/kb/' || \
+             echo "$CHANGED_FILES" | grep -q 'aws_mcp_server/core/data/embeddings/' || \
+             echo "$CHANGED_FILES" | grep -q 'aws_mcp_server/scripts/'; then
+            uv run --frozen generate-embeddings
+          else
+            if uv run --frozen download-latest-embeddings; then
+              echo "Successfully downloaded existing embeddings"
+            else
+              echo "No matching embeddings found, generating new ones..."
+              uv run --frozen generate-embeddings
+            fi
+          fi
+
       - name: Run tests
         working-directory: src/${{ matrix.package }}
         run: |
@@ -154,27 +174,6 @@ jobs:
       - name: Run ruff check
         working-directory: src/${{ matrix.package }}
         run: uv run --frozen ruff check .
-
-      - name: Debug changed files and directories
-        run: |
-          echo "changed-directories: ${{ needs.detect-packages.outputs.changed-directories }}"
-          echo "matrix.package: ${{ matrix.package }}"
-          echo "contains(join(' ', core/kb/'): ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/kb/') }}"
-          echo "contains(join(' ', core/data/embeddings/'): ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/data/embeddings/') }}"
-          echo "contains(join(' ', scripts/'): ${{ contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/scripts/') }}"
-
-      - name: Check for existing embeddings or generate new ones for aws-mcp-server
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-        if: needs.detect-packages.outputs.changed-directories != '[]' && needs.detect-packages.outputs.changed-directories != '' && contains(needs.detect-packages.outputs.changed-directories, matrix.package) && matrix.package == 'aws-mcp-server' && (contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/kb/') || contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/core/data/embeddings/') || contains(needs.detect-packages.outputs.changed-files, 'aws_mcp_server/scripts/'))
-        working-directory: src/${{ matrix.package }}
-        run: |
-          if uv run --frozen download-latest-embeddings; then
-            echo "Successfully downloaded existing embeddings"
-          else
-            echo "No matching embeddings found, generating new ones..."
-            uv run --frozen generate-embeddings
-          fi
 
       - name: Build package
         working-directory: src/${{ matrix.package }}

--- a/src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/dense_retriever.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/dense_retriever.py
@@ -29,7 +29,7 @@ KNOWLEDGE_BASE_SUFFIX = 'knowledge-base-awscli'
 class DenseRetriever:
     """Retrieves documents from a dense index, built by an embedding model.
 
-    The class can receive documents, generate embeddings and cache them to future use.
+    The class can receive documents, generate embeddings and cache them to future use
     """
 
     def __init__(

--- a/src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/dense_retriever.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/core/kb/dense_retriever.py
@@ -29,7 +29,7 @@ KNOWLEDGE_BASE_SUFFIX = 'knowledge-base-awscli'
 class DenseRetriever:
     """Retrieves documents from a dense index, built by an embedding model.
 
-    The class can receive documents, generate embeddings and cache them to future use
+    The class can receive documents, generate embeddings and cache them to future use.
     """
 
     def __init__(

--- a/src/aws-mcp-server/pyproject.toml
+++ b/src/aws-mcp-server/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.9.1",
     "pydantic>=2.10.6",
-    "awscli>=1.40.17",
+    "awscli==1.41.3",
     "boto3>=1.38.18",
     "botocore>=1.38.18",
     "python-json-logger>=2.0.7",

--- a/src/aws-mcp-server/uv.lock
+++ b/src/aws-mcp-server/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.40.35"
+version = "1.41.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -52,9 +52,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/04/92cfb46794779d290aca4c7641bb338e8e0b90093b0d6bece54be2320bf2/awscli-1.40.35.tar.gz", hash = "sha256:a589099d98ce72becc5dc537e30cbcc1578ecb28dbe57486f800139bd6ce233d", size = 1893772 }
+sdist = { url = "https://files.pythonhosted.org/packages/95/ca/c51f088c5f1480e5a390a2383bcd41226c343bdbbb6068aace89035097b8/awscli-1.41.3.tar.gz", hash = "sha256:16242adf9f6688012ddbd5ecb3641712cec5d552dfe6576767eeeacd71d5efaa", size = 1904644 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/87/369048dc2bbb6bd65caba454299859863f100e30575e968f660d09086439/awscli-1.40.35-py3-none-any.whl", hash = "sha256:7142aebc6cb8b6294766a5c1fb81d5c5a7a7d0f5929f9ca031d4d3f97b61ee34", size = 4671798 },
+    { url = "https://files.pythonhosted.org/packages/c9/2d/54ed3737d5c304a50b9b87d5f5bec00832e6e1f310d1c3a9e5dac0199fe4/awscli-1.41.3-py3-none-any.whl", hash = "sha256:8c46d5813ba07283121d4df3659fe712ceff76897d3257be2b394bb58ea45dda", size = 4701430 },
 ]
 
 [[package]]
@@ -93,7 +93,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "awscli", specifier = ">=1.40.17" },
+    { name = "awscli", specifier = "==1.41.3" },
     { name = "boto3", specifier = ">=1.38.18" },
     { name = "botocore", specifier = ">=1.38.18" },
     { name = "faiss-cpu", specifier = ">=1.11.0" },
@@ -124,30 +124,30 @@ dev = [
 
 [[package]]
 name = "boto3"
-version = "1.38.36"
+version = "1.39.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/22/df130d30dcc73b726c3d254ed855806853b86b987052517337587085b6db/boto3-1.38.36.tar.gz", hash = "sha256:efe0aaa060f8fedd76e5c942055f051aee0432fc722d79d8830a9fd9db83593e", size = 111823 }
+sdist = { url = "https://files.pythonhosted.org/packages/02/42/712a74bb86d06538c55067a35b8a82c57aa303eba95b2b1ee91c829288f4/boto3-1.39.3.tar.gz", hash = "sha256:0a367106497649ae3d8a7b571b8c3be01b7b935a0fe303d4cc2574ed03aecbb4", size = 111838 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/ce/f609adc7dfd53792a9b704aa1241f8e5f34c21a5364f64b114d7874f8327/boto3-1.38.36-py3-none-any.whl", hash = "sha256:34c27d7317cadb62c0e9856e5d5aa0271ef47202d340584831048bc7ac904136", size = 139938 },
+    { url = "https://files.pythonhosted.org/packages/15/70/723d2ab259aeaed6c96e5c1857ebe7d474ed9aa8f487dea352c60f33798f/boto3-1.39.3-py3-none-any.whl", hash = "sha256:056cfa2440fe1a157a7c2be897c749c83e1a322144aa4dad889f2fca66571019", size = 139906 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.38.36"
+version = "1.39.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/15/d218917f2d568f6fa92ad3831b31ecc4ee514d775a142385aa87c672bc08/botocore-1.38.36.tar.gz", hash = "sha256:4a1ced1a4218bdff0ed5b46abb54570d473154ddefafa5d121a8d96e4b76ebc1", size = 13966245 }
+sdist = { url = "https://files.pythonhosted.org/packages/60/66/96e89cc261d75f0b8125436272c335c74d2a39df84504a0c3956adcd1301/botocore-1.39.3.tar.gz", hash = "sha256:da8f477e119f9f8a3aaa8b3c99d9c6856ed0a243680aa3a3fbbfc15a8d4093fb", size = 14132316 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/2d/3ccc58837b3ed8322a15b9fd94114a326e6ab29d36a37508aadf9cf7808e/botocore-1.38.36-py3-none-any.whl", hash = "sha256:b6a50b853f6d23af9edfed89a59800c6bc1687a947cdd3492879f7d64e002d30", size = 13623866 },
+    { url = "https://files.pythonhosted.org/packages/53/e4/3698dbb037a44d82a501577c6e3824c19f4289f4afbcadb06793866250d8/botocore-1.39.3-py3-none-any.whl", hash = "sha256:66a81cfac18ad5e9f47696c73fdf44cdbd8f8ca51ab3fca1effca0aabf61f02f", size = 13791724 },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
1. Rebuild embeddings only if there are changes to core knowledge base files.
2. Pin awscli version so its clear which version of embeddings is required

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
