### PR TITLE
chore: add __main__ handler to server.py

### DIFF
--- a/src/aws-mcp-server/awslabs/aws_mcp_server/server.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/server.py
@@ -269,3 +269,7 @@ def main():
         READ_OPERATIONS_INDEX = get_read_only_operations()
 
     server.run(transport='stdio')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
When trying to install and run packaged distribution with different tools, while uvx works, noticed that default python cli fails to call server.main() function when executed like 'python -m awslabs.aws_mcp_server.server"

Thus adding standard idiom to server.py in order to fix this.

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
