### PR TITLE
chore: Adding support for custom cli commands in readonly mode

### DIFF
--- a/src/aws-mcp-server/awslabs/aws_mcp_server/core/metadata/read_only_operations_list.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/core/metadata/read_only_operations_list.py
@@ -43,10 +43,16 @@ class ReadOnlyOperations(dict):
         """Initialize the read only operations list."""
         super().__init__()
         self._service_reference_urls_by_service = service_reference_urls_by_service
+        self.custom_readonly_commands = self._get_custom_readonly_commands()
 
     def has(self, service, operation) -> bool:
         """Check if the operation is in the read only operations list."""
         logger.info(f'checking in read only list : {service} - {operation}')
+        if (
+            service in self.custom_readonly_commands
+            and operation in self.custom_readonly_commands[service]
+        ):
+            return True
         if service not in self:
             if service not in self._service_reference_urls_by_service:
                 return False
@@ -65,6 +71,24 @@ class ReadOnlyOperations(dict):
         for action in response['Actions']:
             if not action['Annotations']['Properties']['IsWrite']:
                 self[service].append(action['Name'])
+
+    def _get_custom_readonly_commands(self) -> dict:
+        return {
+            's3': ['ls', 'presign'],
+            'cloudfront': ['sign'],
+            'cloudtrail': ['validate-logs'],
+            'codeartifact': ['login'],
+            'codecommit': ['credential-helper'],
+            'datapipeline': ['list-runs'],
+            'ecr': ['get-login', 'get-login-password'],
+            'ecr-public': ['get-login-password'],
+            'eks': ['update-kubeconfig', 'get-token'],
+            'emr': ['describe-cluster'],
+            'gamelist': ['get-game-session-log'],
+            'logs': ['start-live-tail'],
+            'rds': ['generate-db-auth-token'],
+            'configservice': ['get-status'],
+        }
 
 
 def get_read_only_operations() -> ReadOnlyOperations:

--- a/src/aws-mcp-server/awslabs/aws_mcp_server/core/metadata/read_only_operations_list.py
+++ b/src/aws-mcp-server/awslabs/aws_mcp_server/core/metadata/read_only_operations_list.py
@@ -43,14 +43,14 @@ class ReadOnlyOperations(dict):
         """Initialize the read only operations list."""
         super().__init__()
         self._service_reference_urls_by_service = service_reference_urls_by_service
-        self.custom_readonly_commands = self._get_custom_readonly_commands()
+        self._custom_readonly_operations = self._get_custom_readonly_operations()
 
     def has(self, service, operation) -> bool:
         """Check if the operation is in the read only operations list."""
         logger.info(f'checking in read only list : {service} - {operation}')
         if (
-            service in self.custom_readonly_commands
-            and operation in self.custom_readonly_commands[service]
+            service in self._custom_readonly_operations
+            and operation in self._custom_readonly_operations[service]
         ):
             return True
         if service not in self:
@@ -72,7 +72,7 @@ class ReadOnlyOperations(dict):
             if not action['Annotations']['Properties']['IsWrite']:
                 self[service].append(action['Name'])
 
-    def _get_custom_readonly_commands(self) -> dict:
+    def _get_custom_readonly_operations(self) -> dict:
         return {
             's3': ['ls', 'presign'],
             'cloudfront': ['sign'],

--- a/src/aws-mcp-server/tests/metadata/test_read_only_operations_list.py
+++ b/src/aws-mcp-server/tests/metadata/test_read_only_operations_list.py
@@ -191,8 +191,8 @@ def test_service_reference_urls_by_service_error(mocked_requests_get):
     )
 
 
-def test_read_only_operations_has_method_custom_command():
-    """Test the has method of ReadOnlyOperations with custom commands."""
+def test_read_only_operations_has_method_custom_operation():
+    """Test the has method of ReadOnlyOperations with custom operations."""
     operations = ReadOnlyOperations({})
     assert operations.has('s3', 'ls')
     assert operations.has('logs', 'start-live-tail')

--- a/src/aws-mcp-server/tests/metadata/test_read_only_operations_list.py
+++ b/src/aws-mcp-server/tests/metadata/test_read_only_operations_list.py
@@ -75,7 +75,7 @@ def sample_service_reference_response():
 def test_read_only_operations_initialization(
     mocked_requests_get, sample_service_reference_list_response
 ):
-    """Test ReadOnlyOperations initialization and version retrieval."""
+    """Test ReadOnlyOperations initialization."""
     mocked_service_reference_list_response = MagicMock(spec=Response)
     mocked_service_reference_list_response.json.return_value = (
         sample_service_reference_list_response
@@ -189,3 +189,11 @@ def test_service_reference_urls_by_service_error(mocked_requests_get):
     mocked_requests_get.assert_has_calls(
         [call(SERVICE_REFERENCE_URL, timeout=DEFAULT_REQUEST_TIMEOUT)], any_order=False
     )
+
+
+def test_read_only_operations_has_method_custom_command():
+    """Test the has method of ReadOnlyOperations with custom commands."""
+    operations = ReadOnlyOperations({})
+    assert operations.has('s3', 'ls')
+    assert operations.has('logs', 'start-live-tail')
+    assert not operations.has('s3', 'sync')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary
Adding support for custom cli commands when read-only mode is enabled.

### Changes

> Please provide a summary of what's being changed

- Added list of custom read-only operations
- Checking both custom readonly operations list as well as service authorization reference to decide if a command is allowed to be executed when read-only mode is enabled.

### User experience

> Please share what the user experience looks like before and after this change

Verified that `aws s3 ls` is working with read-only mode enabled. Previously this used to fail.

## Checklist

Precommit output

```
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check illegal windows names..........................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check that scripts with shebangs are executable..........................Passed
check for broken symlinks............................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check xml............................................(no files to check)Skipped
check non-mkdocs yaml................................(no files to check)Skipped
check mkdocs yaml....................................(no files to check)Skipped
fix end of files.........................................................Passed
debug statements (python)................................................Passed
detect destroyed symlinks................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
forbid submodules....................................(no files to check)Skipped
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
ruff.....................................................................Passed
ruff-format..............................................................Passed
Detect secrets...........................................................Passed
check license header.....................................................Passed
```

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
