### PR TITLE
Recommend AWS MCP as the default MCP server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A suite of specialized MCP servers that help you get the most out of AWS, wherev
   - [Server Sent Events Support Removal](#server-sent-events-support-removal)
   - [Why AWS MCP Servers?](#why-aws-mcp-servers)
   - [Available MCP Servers](#available-mcp-servers)
+    - [ 🚀Getting Started with AWS](#-getting-started-with-aws)
     - [Browse by What You're Building](#browse-by-what-youre-building)
       - [📚 Real-time access to official AWS documentation](#-real-time-access-to-official-aws-documentation)
       - [🏗️ Infrastructure \& Deployment](#️-infrastructure--deployment)
@@ -100,6 +101,12 @@ MCP servers enhance the capabilities of foundation models (FMs) in several key w
 - **Specialized Domain Knowledge**: MCP servers provide deep, contextual knowledge about AWS services that might not be fully represented in foundation models' training data, enabling more accurate and helpful responses for cloud development tasks.
 
 ## Available MCP Servers
+
+### 🚀 Getting Started with AWS
+
+For general AWS interactions and comprehensive API support, we recommend starting with:
+
+- **[AWS MCP Server](src/aws-mcp-server)** - **Start here for general AWS interactions!** Comprehensive AWS API support with command validation, security controls, and access to all AWS services. Perfect for managing infrastructure, exploring resources, and executing AWS operations through natural language.
 
 ### Browse by What You're Building
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->


### Changes

Updated documentation to recommend the AWS MCP Server as the default/primary MCP server for AWS interactions. This change positions the AWS MCP Server as the starting point for users who want comprehensive AWS service integration, while maintaining the existing specialized MCP servers for specific use cases.

### User experience

**Before**: Users had to choose from multiple AWS MCP servers without clear guidance on which one to start with, potentially leading to confusion about the best entry point for AWS interactions.

 **After**: Users now have clear guidance that the AWS MCP Server is the recommended starting point for general AWS interactions, with comprehensive AWS CLI command support and access to the latest AWS services. Other specialized servers are positioned as complementary tools for specific workflows.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

• [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
• [x] I have performed a self-review of this change
• [x] Changes have been tested
• [x] Changes are documented

Is this a breaking change? (Y/N) N

RFC issue number: N/A

Checklist:

• [ ] Migration process documented
• [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the
[project license](https://github.com/awslabs/mcp/blob/main/LICENSE).