### PR TITLE
fix: Adding support for readonly operations where translated operation names are different from IAM operation names

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/metadata/read_only_operations_list.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/metadata/read_only_operations_list.py
@@ -15,6 +15,7 @@ import importlib.resources
 import json
 import requests
 from awslabs.aws_api_mcp_server.core.parser.classifier import METADATA_FILE
+from collections import defaultdict
 from loguru import logger
 from typing import List
 
@@ -83,7 +84,7 @@ class ReadOnlyOperations(dict):
                 self[service].append(action['Name'])
 
     def _get_known_readonly_operations_from_metadata(self) -> dict[str, List[str]]:
-        known_readonly_operations = {}
+        known_readonly_operations = defaultdict(list)
         with (
             importlib.resources.files('awslabs.aws_api_mcp_server.core')
             .joinpath(METADATA_FILE)
@@ -91,10 +92,8 @@ class ReadOnlyOperations(dict):
         ):
             data = json.load(metadata_file)
         for service, operations in data.items():
-            if service not in known_readonly_operations:
-                known_readonly_operations[service] = []
-            for operation in operations:
-                operation_type = data.get(service).get(operation).get('type')
+            for operation, operation_metadata in operations.items():
+                operation_type = operation_metadata.get('type')
                 if operation_type == 'ReadOnly':
                     known_readonly_operations[service].append(operation)
         return known_readonly_operations

--- a/src/aws-api-mcp-server/tests/metadata/test_read_only_operations_list.py
+++ b/src/aws-api-mcp-server/tests/metadata/test_read_only_operations_list.py
@@ -197,3 +197,14 @@ def test_read_only_operations_has_method_custom_operation():
     assert operations.has('s3', 'ls')
     assert operations.has('logs', 'start-live-tail')
     assert not operations.has('s3', 'sync')
+
+
+def test_read_only_operations_has_method_operation_from_metadata():
+    """Test the has method of ReadOnlyOperations with operations defined in api metadata."""
+    operations = ReadOnlyOperations({})
+    assert operations.has('s3', 'ListBuckets')
+    assert operations.has('lambda', 'ListAliases')
+    assert operations.has('rds', 'DescribeDBSnapshotAttributes')
+    assert not operations.has('s3', 'DeleteObject')
+    assert not operations.has('lambda', 'CreateAlias')
+    assert not operations.has('rds', 'CreateDBSecurityGroup')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

In some cases, the names of operations in IAM are different from their names in the service definition in boto3. 
This results in a mismatch and an error message when read-only mode is enabled. 

For example, when `READ_OPERATIONS_ONLY` is set to `true`

```
aws s3api list-buckets
```

Results in 
```
{"error": true,"detail": "Execution of this operation is not allowed because read only mode is enabled. It can be disabled by setting the READ_OPERATIONS_ONLY environment variable to False."}
```

Fixing this by looking up known API classifications from the `api_metadata.json` when operating in readonly mode.

### Changes

> Please provide a summary of what's being changed

- Using the metadata file to find known read-only APIs before looking up in IAM service authorization reference.
- Fixed some type annotations

### User experience

> Please share what the user experience looks like before and after this change

Verified using MCP Inspector that `aws s3api list-buckets` could be executed successfully.


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

Is this a breaking change? N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
