### PR TITLE
feat: Increasing top_k to 5 for suggest_aws_command

### DIFF
--- a/src/aws-api-mcp-server/README.md
+++ b/src/aws-api-mcp-server/README.md
@@ -137,7 +137,7 @@ Once configured, you can ask your AI assistant questions such as:
 
 ## Available MCP Tools
 - `call_aws`: Executes AWS CLI commands with validation and proper error handling
-- `suggest_aws_commands`: Suggests AWS CLI commands based on a natural language query. This tool helps the model generate CLI commands by providing a description and the complete set of parameters for the 3 most likely CLI commands for the given query, including the most recent AWS CLI commands - some of which may be otherwise unknown to the model (released after the model's knowledge cut-off date). This enables RAG (Retrieval-Augmented Generation) for CLI command generation via the AWS CLI command table as the knowledge source, M3 text embedding model [Chen et al., Findings of ACL 2024] for representing query and CLI documents as dense vectors, and FAISS for nearest neighbour search.
+- `suggest_aws_commands`: Suggests AWS CLI commands based on a natural language query. This tool helps the model generate CLI commands by providing a description and the complete set of parameters for the 5 most likely CLI commands for the given query, including the most recent AWS CLI commands - some of which may be otherwise unknown to the model (released after the model's knowledge cut-off date). This enables RAG (Retrieval-Augmented Generation) for CLI command generation via the AWS CLI command table as the knowledge source, M3 text embedding model [Chen et al., Findings of ACL 2024] for representing query and CLI documents as dense vectors, and FAISS for nearest neighbour search.
 
 
 ## Security Considerations

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/kb/dense_retriever.py
@@ -20,7 +20,7 @@ from loguru import logger
 from pathlib import Path
 
 
-DEFAULT_TOP_K = 3
+DEFAULT_TOP_K = 5
 DEFAULT_EMBEDDINGS_MODEL = 'BAAI/bge-base-en-v1.5'
 DEFAULT_CACHE_DIR = Path(__file__).resolve().parent.parent / 'data' / 'embeddings'
 KNOWLEDGE_BASE_SUFFIX = 'knowledge-base-awscli'

--- a/src/aws-api-mcp-server/tests/kb/test_dense_retriever.py
+++ b/src/aws-api-mcp-server/tests/kb/test_dense_retriever.py
@@ -184,7 +184,7 @@ def test_get_suggestions_success():
         {'command': 'aws s3 ls', 'description': 'List S3 buckets'},
         {'command': 'aws lambda list-functions', 'description': 'List Lambda functions'},
         {'command': 'aws logs describe-log-groups', 'description': 'List log groups'},
-        {'command': 'aws sts get-caller-identity', 'description': 'Show current identity'}
+        {'command': 'aws sts get-caller-identity', 'description': 'Show current identity'},
     ]
 
     # Create mock embeddings (3 documents, 384 dimensions like BAAI/bge-base-en-v1.5)
@@ -198,7 +198,7 @@ def test_get_suggestions_success():
         mock_index = MagicMock()
         mock_index.search.return_value = (
             np.array([[0.9, 0.8, 0.7, 0.6, 0.5]]),  # distances
-            np.array([[0, 1, 2, 3 ,4]]),  # indices
+            np.array([[0, 1, 2, 3, 4]]),  # indices
         )
         rag.index = mock_index
 
@@ -299,7 +299,7 @@ def test_get_suggestions_with_mock_model():
         {'command': 'aws s3 ls', 'description': 'List S3 buckets'},
         {'command': 'aws lambda list-functions', 'description': 'List Lambda functions'},
         {'command': 'aws logs describe-log-groups', 'description': 'List log groups'},
-        {'command': 'aws sts get-caller-identity', 'description': 'Show current identity'}
+        {'command': 'aws sts get-caller-identity', 'description': 'Show current identity'},
     ]
 
     # Create mock embeddings

--- a/src/aws-api-mcp-server/tests/kb/test_dense_retriever.py
+++ b/src/aws-api-mcp-server/tests/kb/test_dense_retriever.py
@@ -183,10 +183,12 @@ def test_get_suggestions_success():
         {'command': 'aws ec2 describe-instances', 'description': 'Describe EC2 instances'},
         {'command': 'aws s3 ls', 'description': 'List S3 buckets'},
         {'command': 'aws lambda list-functions', 'description': 'List Lambda functions'},
+        {'command': 'aws logs describe-log-groups', 'description': 'List log groups'},
+        {'command': 'aws sts get-caller-identity', 'description': 'Show current identity'}
     ]
 
     # Create mock embeddings (3 documents, 384 dimensions like BAAI/bge-base-en-v1.5)
-    rag.embeddings = np.random.rand(3, 384).astype('float32')
+    rag.embeddings = np.random.rand(5, 384).astype('float32')
 
     # Mock the model encode method
     with patch.object(rag, '_model') as mock_model:
@@ -195,8 +197,8 @@ def test_get_suggestions_success():
         # Mock the index directly
         mock_index = MagicMock()
         mock_index.search.return_value = (
-            np.array([[0.9, 0.8, 0.7]]),  # distances
-            np.array([[0, 1, 2]]),  # indices
+            np.array([[0.9, 0.8, 0.7, 0.6, 0.5]]),  # distances
+            np.array([[0, 1, 2, 3 ,4]]),  # indices
         )
         rag.index = mock_index
 
@@ -296,10 +298,12 @@ def test_get_suggestions_with_mock_model():
         {'command': 'aws ec2 describe-instances', 'description': 'Describe EC2 instances'},
         {'command': 'aws s3 ls', 'description': 'List S3 buckets'},
         {'command': 'aws lambda list-functions', 'description': 'List Lambda functions'},
+        {'command': 'aws logs describe-log-groups', 'description': 'List log groups'},
+        {'command': 'aws sts get-caller-identity', 'description': 'Show current identity'}
     ]
 
     # Create mock embeddings
-    rag.embeddings = np.random.rand(3, 384).astype('float32')
+    rag.embeddings = np.random.rand(5, 384).astype('float32')
 
     # Mock the model encode method
     with patch.object(rag, '_model') as mock_model:
@@ -308,8 +312,8 @@ def test_get_suggestions_with_mock_model():
         # Mock the index directly
         mock_index = MagicMock()
         mock_index.search.return_value = (
-            np.array([[0.9, 0.8, 0.7]]),  # distances
-            np.array([[0, 1, 2]]),  # indices
+            np.array([[0.9, 0.8, 0.7, 0.6, 0.5]]),  # distances
+            np.array([[0, 1, 2, 3, 4]]),  # indices
         )
         rag.index = mock_index
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Increasing top_k to 5 for suggest_aws_command

### User experience

> The  suggest_aws_command tool will return  5 commands instead of 3

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N) N

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
