### PR TITLE
fix: update tool prompt with working and home directory and encourage absolute paths

### DIFF
--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/helpers.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/common/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import os
 import time
 from botocore.response import StreamingBody
 from contextlib import contextmanager
@@ -52,3 +53,8 @@ class Boto3Encoder(json.JSONEncoder):
 def as_json(boto_response: dict[str, Any]) -> str:
     """Convert a boto3 response dictionary to a JSON string."""
     return json.dumps(boto_response, cls=Boto3Encoder)
+
+
+def expand_user_home_directory(args: list[str]) -> list[str]:
+    """Expand paths beginning with '~' or '~user'."""
+    return [os.path.expanduser(arg) for arg in args]

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/core/parser/parser.py
@@ -57,6 +57,7 @@ from awscli.argparser import ArgTableArgParser, CommandAction, MainArgParser
 from awscli.argprocess import ParamError
 from awscli.arguments import BaseCLIArgument, CLIArgument
 from awscli.clidriver import ServiceCommand
+from awslabs.aws_api_mcp_server.core.common.helpers import expand_user_home_directory
 from botocore.exceptions import ParamValidationError, UndefinedModelAttributeError
 from botocore.model import OperationModel, ServiceModel
 from collections.abc import Generator
@@ -337,8 +338,8 @@ driver._add_aliases(command_table, parser)
 def parse(cli_command: str) -> IRCommand:
     """Parse a CLI command string into an IRCommand object."""
     tokens = split_cli_command(cli_command)
-    # Strip `aws`
-    tokens = tokens[1:]
+    # Strip `aws` and expand paths beginning with ~
+    tokens = expand_user_home_directory(tokens[1:])
     global_args, remaining = parser.parse_known_args(tokens)
     service_command = command_table[global_args.command]
 

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -137,6 +137,7 @@ async def suggest_aws_commands(
     - For cross-region or account-wide operations, explicitly include --region parameter
     - All commands are validated before execution to prevent errors
     - Supports pagination control via max_results parameter
+    - The current working directory is {WORKING_DIRECTORY} and the home directory is {os.path.expanduser('~')}
 
     Best practices for command generation:
     — Always use the most specific service and operation names
@@ -149,6 +150,7 @@ async def suggest_aws_commands(
     - DO NOT use shell redirection operators (>, >>, <)
     - DO NOT use command substitution ($())
     - DO NOT use shell variables or environment variables
+    - DO NOT use relative paths for reading or writing files, use absolute paths instead
 
     Common pitfalls to avoid:
     1. Missing required parameters - always include all required parameters

--- a/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
+++ b/src/aws-api-mcp-server/awslabs/aws_api_mcp_server/server.py
@@ -137,10 +137,11 @@ async def suggest_aws_commands(
     - For cross-region or account-wide operations, explicitly include --region parameter
     - All commands are validated before execution to prevent errors
     - Supports pagination control via max_results parameter
-    - The current working directory is {WORKING_DIRECTORY} and the home directory is {os.path.expanduser('~')}
+    - The current working directory is {WORKING_DIRECTORY}
 
     Best practices for command generation:
     — Always use the most specific service and operation names
+    - Always use the working directory when writing files, unless user explicitly mentioned another directory
     — Include --region when operating across regions
     - Only use filters (--filters, --query, --prefix, --pattern, etc) when necessary or user explicitly asked for it
 

--- a/src/aws-api-mcp-server/tests/parser/test_parser.py
+++ b/src/aws-api-mcp-server/tests/parser/test_parser.py
@@ -608,3 +608,16 @@ def test_outfile_parameter_not_supported(command):
         match='Output file parameters are not supported yet. Use - as the output file to get the requested data in the response.',
     ):
         parse(command)
+
+
+def test_valid_expand_user_home_directory():
+    """Test that tilde is replaced with user home directory."""
+    result = parse(cli_command='aws s3 cp s3://my_file ~/temp/test.txt')
+    assert not any(param.startswith('~') for param in result.parameters['--paths'])
+
+
+def test_invalid_expand_user_home_directory():
+    """Test that tilde is not replaced."""
+    result = parse(cli_command='aws s3 cp s3://my_file ~user_that_does_not_exist/temp/test.txt')
+    print(result)
+    assert any(param.startswith('~') for param in result.parameters['--paths'])


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

- Update tool prompt so the LLM can generate better paths for CLI commands that take in paths for the local filesystem
- Expand `~` so files are placed correctly in the home directory

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
